### PR TITLE
Translate homepage to English and add SEO metadata

### DIFF
--- a/1.html
+++ b/1.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Interactive 7/8 ring simulation and computer crashing game to stress your hardware." />
+    <meta name="keywords" content="computer crashing games, ring simulation, CPU stress test, browser physics, hardware performance" />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content="7/8 Ring Simulation" />
+    <meta property="og:description" content="Interactive 7/8 ring simulation and computer crashing game to stress your hardware." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.cpucry.com/1.html" />
     <title>7/8 Ring Simulation</title>
     <style>
       html, body {

--- a/index.html
+++ b/index.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
-<html lang="tr">
+<html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="description" content="CPUcry Games offers browser-based experiments and computer crashing games that push your hardware to the limit."/>
+  <meta name="keywords" content="computer crashing games, CPU stress test, browser simulations, hardware stress, web experiments"/>
+  <meta name="robots" content="index, follow"/>
+  <meta property="og:title" content="CPUcry Games"/>
+  <meta property="og:description" content="Browser-based experiments and computer crashing games that push your hardware to the limit."/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:url" content="https://www.cpucry.com/"/>
   <title>CPUcry Games</title>
   <style>
     :root {
@@ -52,8 +59,8 @@
 <body>
   <main>
     <h1>CPUcry Games</h1>
-    <p>Tarayıcıda eğlenceli deneyler ve simülasyonlar.</p>
-    <a class="button" href="1.html">7/8 Ring Simülasyonu</a>
+    <p>Fun browser-based experiments and simulations, including computer crashing games.</p>
+    <a class="button" href="1.html">7/8 Ring Simulation</a>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Translate homepage into English and provide link text in English.
- Add meta description, keywords, robots, and Open Graph tags for better search visibility.
- Add similar SEO metadata to the ring simulation page.

## Testing
- `npx --yes htmlhint index.html 1.html`

------
https://chatgpt.com/codex/tasks/task_b_6897c2348c14832eac7d5125c846ee20