### PR TITLE
Shrink thumbnails and arrange horizontally

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,19 +42,21 @@
     }
     .games {
       display: flex;
-      flex-direction: column;
+      flex-wrap: wrap;
       gap: 1rem;
-      align-items: center;
+      align-items: flex-start;
+      justify-content: flex-start;
     }
     .game {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
       align-items: center;
+      width: 96px;
     }
     .game img {
       width: 100%;
-      max-width: 320px;
+      max-width: 96px;
       border-radius: 8px;
       box-shadow: 0 4px 16px rgba(0,0,0,0.25);
     }


### PR DESCRIPTION
## Summary
- reduce index page thumbnail size
- display game thumbnails side-by-side with wrapping

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/cpucry.com/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_6898b61f2cd4832e9d8a789eadc325b7