### PR TITLE
Add JSON-LD metadata to game pages

### DIFF
--- a/games/1.html
+++ b/games/1.html
@@ -11,6 +11,19 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.cpucry.com/games/1.html" />
     <title>7/8 Ring Simulation</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "VideoGame",
+      "name": "7/8 Ring Simulation",
+      "url": "https://www.cpucry.com/games/1.html",
+      "applicationCategory": "BrowserGame",
+      "operatingSystem": "Web",
+      "genre": "Arcade, Physics",
+      "author": {"@type": "Person", "name": "Onur Girşen"},
+      "description": "Interactive 7/8 ring simulation and computer crashing game to stress your hardware."
+    }
+    </script>
     <style>
       html, body {
         margin: 0;

--- a/games/2.html
+++ b/games/2.html
@@ -9,13 +9,26 @@
   <meta property="og:title" content="Bouncing Ball with Infinite Speed" />
   <meta property="og:description" content="Interactive bouncing ball game with dynamic speed controls and limitless acceleration." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.cpucry.com/games/2.html" />
-  <link rel="canonical" href="https://www.cpucry.com/games/2.html" />
-  <title>Bouncing Ball with Infinite Speed</title>
-  <style>
-    :root { --bg: #0f1220; --ring: #e2e8f0; --ball: #60a5fa; --hud: #94a3b8; }
-    html, body { height: 100%; margin: 0; background: radial-gradient(1200px 800px at 70% 20%, #151933 0%, #0f1220 70%); color: white; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
-    #wrap { position: relative; height: 100%; width: 100%; }
+    <meta property="og:url" content="https://www.cpucry.com/games/2.html" />
+    <link rel="canonical" href="https://www.cpucry.com/games/2.html" />
+    <title>Bouncing Ball with Infinite Speed</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "VideoGame",
+      "name": "Bouncing Ball with Infinite Speed",
+      "url": "https://www.cpucry.com/games/2.html",
+      "applicationCategory": "BrowserGame",
+      "operatingSystem": "Web",
+      "genre": "Arcade, Physics",
+      "author": {"@type": "Person", "name": "Onur Girşen"},
+      "description": "Interactive bouncing ball game with dynamic speed controls and limitless acceleration."
+    }
+    </script>
+    <style>
+      :root { --bg: #0f1220; --ring: #e2e8f0; --ball: #60a5fa; --hud: #94a3b8; }
+      html, body { height: 100%; margin: 0; background: radial-gradient(1200px 800px at 70% 20%, #151933 0%, #0f1220 70%); color: white; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
+      #wrap { position: relative; height: 100%; width: 100%; }
     canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
 
     .hud { position: absolute; top: 12px; left: 12px; padding: 8px 10px; background: rgba(15,18,32,0.6); border: 1px solid rgba(226,232,240,0.15); border-radius: 10px; font-size: 12px; color: var(--hud); user-select: none; backdrop-filter: blur(6px); z-index: 2; }

--- a/games/3.html
+++ b/games/3.html
@@ -4,6 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Exponential Chart — 0.5s Predictive Autoscale · 0.1s Step · m=1.03</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoGame",
+    "name": "Exponential Chart — 0.5s Predictive Autoscale · 0.1s Step · m=1.03",
+    "url": "https://www.cpucry.com/games/3.html",
+    "applicationCategory": "BrowserGame",
+    "operatingSystem": "Web",
+    "genre": "Simulation",
+    "author": {"@type": "Person", "name": "Onur Girşen"},
+    "description": "Interactive exponential chart simulation with predictive autoscaling and adjustable multiplier."
+  }
+  </script>
   <style>
     :root {
       --bg: #0b0f14;

--- a/games/4.html
+++ b/games/4.html
@@ -4,6 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Reflective Laser – Ultra Fast</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoGame",
+    "name": "Reflective Laser – Ultra Fast",
+    "url": "https://www.cpucry.com/games/4.html",
+    "applicationCategory": "BrowserGame",
+    "operatingSystem": "Web",
+    "genre": "Arcade, Physics",
+    "author": {"@type": "Person", "name": "Onur Girşen"},
+    "description": "High-speed reflective laser browser game with customizable performance and visual settings."
+  }
+  </script>
   <style>
     :root { color-scheme: dark; }
     html, body { height: 100%; }


### PR DESCRIPTION
## Summary
- embed VideoGame schema.org JSON-LD metadata into each game page for richer SEO snippets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a6eb0c4ec832e8f661aa965388e78