### PR TITLE
Add canonical and meta tags to game pages

### DIFF
--- a/games/1.html
+++ b/games/1.html
@@ -10,6 +10,7 @@
     <meta property="og:description" content="Interactive 7/8 ring simulation and computer crashing game to stress your hardware." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.cpucry.com/games/1.html" />
+    <link rel="canonical" href="https://www.cpucry.com/games/1.html" />
     <title>7/8 Ring Simulation</title>
     <script type="application/ld+json">
     {

--- a/games/3.html
+++ b/games/3.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Interactive exponential chart simulation with predictive autoscaling and adjustable multiplier." />
+  <meta property="og:title" content="Exponential Chart — 0.5s Predictive Autoscale · 0.1s Step · m=1.03" />
+  <meta property="og:description" content="Interactive exponential chart simulation with predictive autoscaling and adjustable multiplier." />
+  <meta property="og:url" content="https://www.cpucry.com/games/3.html" />
+  <meta property="og:image" content="https://www.cpucry.com/images/3.png" />
+  <link rel="canonical" href="https://www.cpucry.com/games/3.html" />
   <title>Exponential Chart — 0.5s Predictive Autoscale · 0.1s Step · m=1.03</title>
   <script type="application/ld+json">
   {

--- a/games/4.html
+++ b/games/4.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="High-speed reflective laser browser game with customizable performance and visual settings." />
+  <meta property="og:title" content="Reflective Laser – Ultra Fast" />
+  <meta property="og:description" content="High-speed reflective laser browser game with customizable performance and visual settings." />
+  <meta property="og:url" content="https://www.cpucry.com/games/4.html" />
+  <meta property="og:image" content="https://www.cpucry.com/images/4.png" />
+  <link rel="canonical" href="https://www.cpucry.com/games/4.html" />
   <title>Reflective Laser – Ultra Fast</title>
   <script type="application/ld+json">
   {


### PR DESCRIPTION
## Summary
- add canonical link to game pages 1, 3, and 4
- define description and Open Graph meta tags for games 3 and 4

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a727df948832ea5f242119907f816