### PR TITLE
Add lazy loading and dimensions to homepage images

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,25 +89,25 @@
     <div class="games">
       <div class="game">
         <a href="games/1.html">
-          <img src="images/1.png" alt="7/8 Ring Simulation screenshot" />
+          <img src="images/1.png" alt="7/8 Ring Simulation screenshot" loading="lazy" width="476" height="471" />
         </a>
         <a class="button" href="games/1.html">7/8 Ring Simulation</a>
       </div>
       <div class="game">
         <a href="games/2.html">
-          <img src="images/2.png" alt="Bouncing Ball with Infinite Speed screenshot" />
+          <img src="images/2.png" alt="Bouncing Ball with Infinite Speed screenshot" loading="lazy" width="545" height="509" />
         </a>
         <a class="button" href="games/2.html">Bouncing Ball with Infinite Speed</a>
       </div>
       <div class="game">
         <a href="games/3.html">
-          <img src="images/3.png" alt="Exponential Chart screenshot" />
+          <img src="images/3.png" alt="Exponential Chart screenshot" loading="lazy" width="563" height="592" />
         </a>
         <a class="button" href="games/3.html">Exponential Chart</a>
       </div>
       <div class="game">
         <a href="games/4.html">
-          <img src="images/4.png" alt="Reflective Laser – Ultra Fast screenshot" />
+          <img src="images/4.png" alt="Reflective Laser – Ultra Fast screenshot" loading="lazy" width="783" height="575" />
         </a>
         <a class="button" href="games/4.html">Reflective Laser – Ultra Fast</a>
       </div>


### PR DESCRIPTION
## Summary
- specify width/height for homepage screenshots
- enable lazy loading on homepage screenshots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a7281b23c832eb73822840c5b2ad5