### PR TITLE
chore: drop meta keywords and refine descriptions

### DIFF
--- a/games/1.html
+++ b/games/1.html
@@ -3,11 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Interactive 7/8 ring simulation and computer crashing game to stress your hardware." />
-    <meta name="keywords" content="computer crashing games, ring simulation, CPU stress test, browser physics, hardware performance" />
+    <meta name="description" content="Push your processor with the 7/8 Ring Simulation, a physics experiment and computer-crashing browser game." />
     <meta name="robots" content="index, follow" />
     <meta property="og:title" content="7/8 Ring Simulation" />
-    <meta property="og:description" content="Interactive 7/8 ring simulation and computer crashing game to stress your hardware." />
+    <meta property="og:description" content="Push your processor with the 7/8 Ring Simulation, a physics experiment and computer-crashing browser game." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.cpucry.com/games/1.html" />
     <title>7/8 Ring Simulation</title>

--- a/games/2.html
+++ b/games/2.html
@@ -3,11 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Bouncing Ball with Infinite Speed is an interactive browser simulation where you control a ball's gain and maximum speed inside a circular arena." />
-  <meta name="keywords" content="bouncing ball, infinite speed, computer crashing game, speed gain control, browser physics simulation" />
+  <meta name="description" content="Control acceleration in Bouncing Ball with Infinite Speed, a browser simulation that tests hardware limits inside a circular arena." />
   <meta name="robots" content="index, follow" />
   <meta property="og:title" content="Bouncing Ball with Infinite Speed" />
-  <meta property="og:description" content="Interactive bouncing ball game with dynamic speed controls and limitless acceleration." />
+  <meta property="og:description" content="Control acceleration in Bouncing Ball with Infinite Speed, a browser simulation that tests hardware limits inside a circular arena." />
   <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.cpucry.com/games/2.html" />
     <link rel="canonical" href="https://www.cpucry.com/games/2.html" />

--- a/index.html
+++ b/index.html
@@ -3,11 +3,10 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="CPUcry Games offers browser-based experiments and computer crashing games that push your hardware to the limit."/>
-  <meta name="keywords" content="computer crashing games, CPU stress test, browser simulations, hardware stress, web experiments"/>
+  <meta name="description" content="Explore CPUcry Games, a collection of physics experiments and CPU-stressing browser games."/>
   <meta name="robots" content="index, follow"/>
   <meta property="og:title" content="CPUcry Games"/>
-  <meta property="og:description" content="Browser-based experiments and computer crashing games that push your hardware to the limit."/>
+  <meta property="og:description" content="Explore CPUcry Games, a collection of physics experiments and CPU-stressing browser games."/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://www.cpucry.com/"/>
   <title>CPUcry Games</title>


### PR DESCRIPTION
## Summary
- remove outdated `meta keywords` tags from main pages
- rewrite `meta description` and Open Graph descriptions with more specific phrasing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a72c1889c832e9d22bfbea60da64e