### PR TITLE
Add Circular Bounce Simulation game to site

### DIFF
--- a/games/6.html
+++ b/games/6.html
@@ -1,9 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Physics-based simulation of a ball bouncing within an expanding circle with adjustable growth factor and performance chart." />
+  <meta name="keywords" content="circular bounce simulation, physics simulation, browser game, computer crashing games, hardware stress test" />
+  <meta name="robots" content="index, follow" />
+  <meta property="og:title" content="Circular Bounce Simulation" />
+  <meta property="og:description" content="Physics-based simulation of a ball bouncing within an expanding circle with adjustable growth factor and performance chart." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.cpucry.com/games/6.html" />
+  <meta property="og:image" content="https://www.cpucry.com/images/6.png" />
+  <link rel="canonical" href="https://www.cpucry.com/games/6.html" />
   <title>Circular Bounce Simulation</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoGame",
+    "name": "Circular Bounce Simulation",
+    "url": "https://www.cpucry.com/games/6.html",
+    "applicationCategory": "BrowserGame",
+    "operatingSystem": "Web",
+    "genre": "Simulation, Physics",
+    "author": {"@type": "Person", "name": "Onur Girşen"},
+    "description": "Physics-based simulation of a ball bouncing within an expanding circle with adjustable growth factor and performance chart."
+  }
+  </script>
   <style>
     :root{
       --panel-bg: rgba(20,22,28,0.6);

--- a/index.html
+++ b/index.html
@@ -120,6 +120,12 @@
         </a>
         <a class="button" href="games/5.html">Pixel Particle Game</a>
       </div>
+      <div class="game">
+        <a href="games/6.html">
+          <img src="images/6.png" alt="Circular Bounce Simulation screenshot" />
+        </a>
+        <a class="button" href="games/6.html">Circular Bounce Simulation</a>
+      </div>
     </div>
   </main>
 </body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,4 +18,7 @@
   <url>
     <loc>https://www.cpucry.com/games/5.html</loc>
   </url>
+  <url>
+    <loc>https://www.cpucry.com/games/6.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Link Circular Bounce Simulation from the homepage with thumbnail and button
- Add Circular Bounce Simulation page to sitemap
- Add SEO metadata, Open Graph tags, and JSON-LD to game page

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bbe8bfc4c832ea3fe3dbdf5d86f1f