### PR TITLE
Add games 7 and 8 to index and sitemap

### DIFF
--- a/games/7.html
+++ b/games/7.html
@@ -3,7 +3,29 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Interactive neutron chain reaction simulation with cascading rod fission and neutron bursts." />
+  <meta name="keywords" content="neutron chain reaction, nuclear simulation, browser game, computer crashing games, hardware stress test" />
+  <meta name="robots" content="index, follow" />
+  <meta property="og:title" content="Neutron Chain Reaction — HTML Simulation" />
+  <meta property="og:description" content="Interactive neutron chain reaction simulation with cascading rod fission and neutron bursts." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.cpucry.com/games/7.html" />
+  <meta property="og:image" content="https://www.cpucry.com/images/7.png" />
+  <link rel="canonical" href="https://www.cpucry.com/games/7.html" />
   <title>Neutron Chain Reaction — HTML Simulation</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoGame",
+    "name": "Neutron Chain Reaction — HTML Simulation",
+    "url": "https://www.cpucry.com/games/7.html",
+    "applicationCategory": "BrowserGame",
+    "operatingSystem": "Web",
+    "genre": "Simulation, Physics",
+    "author": {"@type": "Person", "name": "Onur Girşen"},
+    "description": "Interactive neutron chain reaction simulation with cascading rod fission and neutron bursts."
+  }
+  </script>
   <style>
     :root {
       --bg: #0b0d10;

--- a/games/8.html
+++ b/games/8.html
@@ -3,7 +3,29 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Pixel-based water simulation where cascading raindrops multiply on impact and quickly flood the screen." />
+  <meta name="keywords" content="pixel water simulation, raindrop cascade, browser game, computer crashing games, hardware stress test" />
+  <meta name="robots" content="index, follow" />
+  <meta property="og:title" content="Pixel Water — Raindrop Cascade" />
+  <meta property="og:description" content="Pixel-based water simulation where cascading raindrops multiply on impact and quickly flood the screen." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.cpucry.com/games/8.html" />
+  <meta property="og:image" content="https://www.cpucry.com/images/8.png" />
+  <link rel="canonical" href="https://www.cpucry.com/games/8.html" />
   <title>Pixel Water — Raindrop Cascade</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoGame",
+    "name": "Pixel Water — Raindrop Cascade",
+    "url": "https://www.cpucry.com/games/8.html",
+    "applicationCategory": "BrowserGame",
+    "operatingSystem": "Web",
+    "genre": "Simulation",
+    "author": {"@type": "Person", "name": "Onur Girşen"},
+    "description": "Pixel-based water simulation where cascading raindrops multiply on impact and quickly flood the screen."
+  }
+  </script>
   <style>
     :root{
       --bg:#0a0d14; /* deep night */

--- a/index.html
+++ b/index.html
@@ -126,6 +126,18 @@
         </a>
         <a class="button" href="games/6.html">Circular Bounce Simulation</a>
       </div>
+      <div class="game">
+        <a href="games/7.html">
+          <img src="images/7.png" alt="Neutron Chain Reaction screenshot" />
+        </a>
+        <a class="button" href="games/7.html">Neutron Chain Reaction</a>
+      </div>
+      <div class="game">
+        <a href="games/8.html">
+          <img src="images/8.png" alt="Pixel Water — Raindrop Cascade screenshot" />
+        </a>
+        <a class="button" href="games/8.html">Pixel Water — Raindrop Cascade</a>
+      </div>
     </div>
   </main>
 </body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,4 +21,10 @@
   <url>
     <loc>https://www.cpucry.com/games/6.html</loc>
   </url>
+  <url>
+    <loc>https://www.cpucry.com/games/7.html</loc>
+  </url>
+  <url>
+    <loc>https://www.cpucry.com/games/8.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- List new Neutron Chain Reaction and Pixel Water games on the home page.
- Register new game pages in the sitemap.
- Add SEO meta tags and JSON-LD metadata for games 7 and 8.

## Testing
- `npx --yes prettier --check index.html games/7.html games/8.html` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_b_689d0e0977f4832e924a5c1e911b8245