### PR TITLE
Add new games 9–13 to index and sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,36 @@
         </a>
         <a class="button" href="games/8.html">Pixel Water — Raindrop Cascade</a>
       </div>
+      <div class="game">
+        <a href="games/9.html">
+          <img src="images/9.png" alt="Particle Rain — O(n²) Collisions screenshot" />
+        </a>
+        <a class="button" href="games/9.html">Particle Rain — O(n²) Collisions</a>
+      </div>
+      <div class="game">
+        <a href="games/10.html">
+          <img src="images/10.png" alt="Replicating Pixels — Crashy Demo screenshot" />
+        </a>
+        <a class="button" href="games/10.html">Replicating Pixels — Crashy Demo</a>
+      </div>
+      <div class="game">
+        <a href="games/11.html">
+          <img src="images/11.png" alt="Growing Numbers — Fibonacci Crash Demo screenshot" />
+        </a>
+        <a class="button" href="games/11.html">Growing Numbers — Fibonacci Crash Demo</a>
+      </div>
+      <div class="game">
+        <a href="games/12.html">
+          <img src="images/12.png" alt="Chaos Snowflakes — DOM Split Demo screenshot" />
+        </a>
+        <a class="button" href="games/12.html">Chaos Snowflakes — DOM Split Demo</a>
+      </div>
+      <div class="game">
+        <a href="games/13.html">
+          <img src="images/13.png" alt="Pixel Collision Simulation screenshot" />
+        </a>
+        <a class="button" href="games/13.html">Pixel Collision Simulation</a>
+      </div>
     </div>
   </main>
 </body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -27,4 +27,19 @@
   <url>
     <loc>https://www.cpucry.com/games/8.html</loc>
   </url>
+  <url>
+    <loc>https://www.cpucry.com/games/9.html</loc>
+  </url>
+  <url>
+    <loc>https://www.cpucry.com/games/10.html</loc>
+  </url>
+  <url>
+    <loc>https://www.cpucry.com/games/11.html</loc>
+  </url>
+  <url>
+    <loc>https://www.cpucry.com/games/12.html</loc>
+  </url>
+  <url>
+    <loc>https://www.cpucry.com/games/13.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add game cards for new games 9–13 on the homepage
- include new game URLs in sitemap for search engines

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_b_689e098af350832ea02b5a867de83ac2